### PR TITLE
chore :: baseurl 삭제

### DIFF
--- a/src/apis/admin/index.ts
+++ b/src/apis/admin/index.ts
@@ -18,7 +18,7 @@ interface Token {
 }
 
 export const useLogin = () => {
-  const BASEURL = process.env.VITE_SERVER_BASE_URL
+  const BASEURL = process.env.VITE_SERVER_BASE_URL;
 
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState<string | null>(null);
@@ -26,7 +26,7 @@ export const useLogin = () => {
   const loginMutation = useMutation<Token, Error, Login>({
     mutationFn: (param: Login) => {
       return axios
-        .post<Token>(`${BASEURL}${router}/login`, {
+        .post<Token>(`${router}/login`, {
           ...param,
         })
         .then((response) => {

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,7 +1,7 @@
 import { cookie } from "@/utils/auth";
 import axios, { AxiosError } from "axios";
 
-const BASEURL = process.env.VITE_SERVER_BASE_URL
+const BASEURL = "";
 
 export const instance = axios.create({
   baseURL: BASEURL,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * API 기본 경로를 절대 URL에서 현재 도메인 기준의 상대 경로로 전환.
  * 관리자 로그인 및 토큰 갱신 요청 엔드포인트를 상대 경로로 일관화하여 실행 중인 도메인을 자동으로 따르도록 조정.
  * 기능 동작은 동일하나, 요청 대상 호스트 결정 방식이 변경되어 다양한 배포 환경에서 일관된 네트워크 동작을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->